### PR TITLE
Update TurnbullWakemanAsian.c

### DIFF
--- a/src/models/metaoptions/src/TurnbullWakemanAsian.c
+++ b/src/models/metaoptions/src/TurnbullWakemanAsian.c
@@ -54,7 +54,7 @@ double TurnbullWakemanAsian(
 	b2vv = b2 + vv;
 	t22 = pow(T2-tau, 2.0);
 
-    m1 = (exp(b * T2) - exp(b * tau)) / (b * (T2 - tau));
+    m1 = b ? (exp(b * T2) - exp(b * tau)) / (b * (T2 - tau)) : 1.0;
     m2 	= 2.0 * exp(b2vv * T2)  / (bvv * b2vv * t22) 
 		+ 2.0 * exp(b2vv * tau) / (b * t22) 
 		* (1.0 / b2vv - exp(b * (T2 - tau)) / bvv);


### PR DESCRIPTION
Fixed division by zero. The first moment should be 1 if the cost-of-carry is zero. This is also consistent to the Complete Guide To Option Pricing book.
